### PR TITLE
Fixes buffer overflow vulnerability and a typo and adds a period.

### DIFF
--- a/ContactsManagement/main.c
+++ b/ContactsManagement/main.c
@@ -55,7 +55,7 @@ printf("address:");
 scanf("%[^\n]",&list.add);
 fflush(stdin);
 printf("email address:");
-gets(list.email);
+fgets(list.email,30,stdin);
 printf("\n");
 fwrite(&list,sizeof(list),1,fp);
 }
@@ -163,7 +163,7 @@ printf("..::address:");
 scanf("%[^\n]",&list.add);
 fflush(stdin);
 printf("..::email address:");
-gets(list.email);
+fgets(list.email,30,stdin);
 printf("\n");
 fwrite(&list,sizeof(list),1,ft);
 fclose(fp);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-Mini Projects written in C for begineer. Detail of all projects are in http://codeincodeblock.com/
+Mini Projects written in C for beginner. Detail of all projects are in http://codeincodeblock.com/.
 
 List of articles:
 


### PR DESCRIPTION
According to the man page of gets(), it is better to use the fgets() function rather than the gets() function because the gets() function allows the user to control what the program does via a buffer overflow exploit and is generally not recommended by many. Let's say there's a contact manager like this one that ran on a server many people use and people should only be allowed to manage their own contacts. One would be able to take advantage of the buffer overflow vulnerability to make the program list other people's contacts too and that would be an invasion of privacy. Given that programs like these are meant to teach a beginner, it would be better for a beginner to use a function with no security vulnerabilities so that they won't use an unsafe function in real life programs that are used by more than one person.